### PR TITLE
Implement analytics dashboard renderer with dynamic filters

### DIFF
--- a/src/routes/pageRoutes.js
+++ b/src/routes/pageRoutes.js
@@ -7,6 +7,7 @@ const router = express.Router();
 // Import page handlers
 const renderHomePage = require('./pages/homePage');  // No destructuring
 const { renderDashboardPage } = require('./pages/dashboardPage');  // Keep destructuring
+const { renderAnalyticsPage } = require('./pages/analyticsPage');
 
 // Import services for test page and AI intelligence page
 const dbService = require('../services/dbService');
@@ -22,9 +23,7 @@ router.get('/', renderHomePage);
 router.get('/dashboard', renderDashboardPage);
 
 // ANALYTICS PAGE
-router.get('/analytics', (req, res) => {
-    res.send('<h1>Analytics Page - Coming Soon</h1><p><a href="/">← Back to Home</a></p>');
-});
+router.get('/analytics', renderAnalyticsPage);
 
 // WEEKLY ROUNDUP PAGE - NEW
 router.get('/weekly-roundup', async (req, res) => {

--- a/src/routes/pages/homePage.js
+++ b/src/routes/pages/homePage.js
@@ -60,7 +60,43 @@ async function renderHomePage(req, res) {
                     margin-left: auto;
                     margin-right: auto;
                 }
-                
+
+                .hero-actions {
+                    display: flex;
+                    justify-content: center;
+                    gap: 16px;
+                    margin-bottom: 32px;
+                    flex-wrap: wrap;
+                }
+
+                .hero-button {
+                    display: inline-flex;
+                    align-items: center;
+                    gap: 10px;
+                    padding: 14px 24px;
+                    border-radius: 999px;
+                    font-weight: 600;
+                    text-decoration: none;
+                    transition: transform 0.2s ease, box-shadow 0.2s ease;
+                    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
+                }
+
+                .hero-button.primary {
+                    background: #ffffff;
+                    color: #4f46e5;
+                }
+
+                .hero-button.secondary {
+                    background: rgba(255, 255, 255, 0.15);
+                    color: #ffffff;
+                    border: 1px solid rgba(255, 255, 255, 0.4);
+                }
+
+                .hero-button:hover {
+                    transform: translateY(-3px);
+                    box-shadow: 0 16px 30px rgba(0, 0, 0, 0.25);
+                }
+
                 .hero-stats {
                     display: grid;
                     grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
@@ -402,7 +438,17 @@ async function renderHomePage(req, res) {
                     .hero-title {
                         font-size: 2rem;
                     }
-                    
+
+                    .hero-actions {
+                        flex-direction: column;
+                        align-items: stretch;
+                    }
+
+                    .hero-button {
+                        justify-content: center;
+                        width: 100%;
+                    }
+
                     .hero-stats {
                         grid-template-columns: repeat(2, 1fr);
                     }
@@ -636,10 +682,21 @@ async function renderHomePage(req, res) {
                     <section class="hero-section">
                         <h1 class="hero-title">🤖 AI Regulatory Intelligence Platform</h1>
                         <p class="hero-subtitle">
-                            Transform regulatory compliance with AI-powered insights, proactive intelligence, 
+                            Transform regulatory compliance with AI-powered insights, proactive intelligence,
                             and automated business impact analysis for UK financial services
                         </p>
-                        
+
+                        <div class="hero-actions">
+                            <a href="/analytics" class="hero-button primary">
+                                <span>📈</span>
+                                <span>Launch Analytics Dashboard</span>
+                            </a>
+                            <a href="/dashboard" class="hero-button secondary">
+                                <span>📊</span>
+                                <span>View Live Intelligence</span>
+                            </a>
+                        </div>
+
                         <div class="hero-stats">
                             <div class="hero-stat">
                                 <span class="hero-stat-number">${systemStats.totalUpdates}</span>

--- a/src/routes/templates/sidebar.js
+++ b/src/routes/templates/sidebar.js
@@ -42,6 +42,7 @@ async function getSidebar(currentPage = '') {
                         <a href="/analytics" class="nav-link">
                             <span class="nav-icon">📈</span>
                             <span class="nav-text">Analytics</span>
+                            <span class="nav-badge new">NEW</span>
                         </a>
                     </li>
                     <li class="nav-item ${currentPage === 'ai-intelligence' ? 'active' : ''}">


### PR DESCRIPTION
## Summary
- replace the analytics placeholder with a server-rendered dashboard that loads statistics and filter metadata from the database services
- add client-side analytics helpers to drive filter changes, update the URL, and stream refreshed impact distributions from the analytics API endpoints
- refresh the navigation badge and home hero call-to-actions so the analytics experience is prominently promoted

## Testing
- npm test *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_68cc67588ff8832788804ec5a27c1fdc